### PR TITLE
Fix & clean importer (fixes #5)

### DIFF
--- a/src/Command/BaseImportCommand.php
+++ b/src/Command/BaseImportCommand.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\BatchEntry;
+use App\Entity\BatchEntryPlace;
+use App\Repository\BatchEntryPlaceRepository;
+use App\Repository\BatchEntryRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Serializer\Encoder\CsvEncoder;
+use Symfony\Component\Serializer\Serializer;
+
+abstract class BaseImportCommand extends Command
+{
+    const FLUSH_LIMIT = 5000;
+    const CSV_FILE = '';
+    const TARGET_VALUE = '';
+    const DELIMITER = ';';
+
+    protected EntityManagerInterface $entityManager;
+    private BatchEntryRepository $batchEntryRepository;
+    private BatchEntryPlaceRepository $batchEntryPlaceRepository;
+
+    /**
+     * @var BatchEntryPlace[]
+     */
+    private array $places = [];
+
+    /**
+     * @var BatchEntry[]
+     */
+    private array $entries = [];
+
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        BatchEntryRepository $batchEntryRepository,
+        BatchEntryPlaceRepository $batchEntryPlaceRepository
+    ) {
+        $this->entityManager = $entityManager;
+        $this->batchEntryRepository = $batchEntryRepository;
+        $this->batchEntryPlaceRepository = $batchEntryPlaceRepository;
+
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->write('Reading [' . self::CSV_FILE . ']...');
+        $fileContent = file_get_contents(self::CSV_FILE);
+        $io->writeln(' done.');
+
+        if (!$fileContent) {
+            $io->error('Failed to open file');
+
+            return self::FAILURE;
+        }
+
+        $serializer = new Serializer([], [new CsvEncoder([
+            CsvEncoder::NO_HEADERS_KEY => true,
+            CsvEncoder::DELIMITER_KEY => static::DELIMITER,
+        ])]);
+
+        $io->write('Importing...');
+        $csvContent = $serializer->decode($fileContent, 'csv');
+        $total = count($csvContent);
+        $io->writeln($total . ' entries.');
+
+        $i = 0;
+        foreach ($csvContent as $csvLine) {
+            $companyName = trim($csvLine[0]);
+            $place = $this->findOrCreatePlace(trim($csvLine[1]));
+            $amount = (int) str_replace(['.', ','], '', $csvLine[2]);
+
+            $this->findOrCreateEntry($companyName, $place, static::TARGET_VALUE, $amount);
+
+            if ($i > 0 && $i % static::FLUSH_LIMIT === 0) {
+                $io->writeln("Flushing @ ${i} / ${total}...");
+                $this->flush();
+            }
+
+            ++$i;
+        }
+
+        $io->writeln("Flushing @ ${i} / ${total}");
+        $this->flush();
+
+        $io->success('Finished importing ' . static::CSV_FILE);
+
+        return self::SUCCESS;
+    }
+
+    protected function flush()
+    {
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+        $this->clearEntries();
+        gc_collect_cycles();
+    }
+
+    protected function clearEntries(): void
+    {
+        $this->places = [];
+        $this->entries = [];
+    }
+
+    protected function findOrCreatePlace(string $placeName): BatchEntryPlace
+    {
+        // First find in local cache
+        if (array_key_exists($placeName, $this->places)) {
+            return $this->places[$placeName];
+        }
+
+        // Then in db
+        $existingPlace = $this->batchEntryPlaceRepository->findOneBy([
+            'name' => $placeName,
+        ]);
+
+        if ($existingPlace != null) {
+            $this->places[$placeName] = $existingPlace;
+
+            return $existingPlace;
+        }
+
+        // Otherwise persist new and cache
+        $newPlace = new BatchEntryPlace($placeName);
+        $this->entityManager->persist($newPlace);
+        $this->places[$placeName] = $newPlace;
+
+        return $newPlace;
+    }
+
+    protected function findOrCreateEntry(string $companyName, BatchEntryPlace $place, $updateKey, int $updateValue): void
+    {
+        $entryIndex = md5($companyName . $place->getName());
+        $callSetter = 'set' . $updateKey;
+        // First find in local cache
+        if (array_key_exists($entryIndex, $this->entries)) {
+            $this->entries[$entryIndex]->$callSetter($updateValue);
+            $this->entries[$entryIndex]->recalculateTotalAmount();
+
+            return;
+        }
+
+        // Then in db
+        $existingEntries = $this->batchEntryRepository->findBy([
+            'companyName' => $companyName,
+            'place' => $place,
+        ]);
+
+        // If not able to match exactly ONE entry with same name and place, create new one
+        if (count($existingEntries) !== 1) {
+            /* @var $newEntry BatchEntry */
+            $newEntry = (new BatchEntry($companyName, $place))->$callSetter($updateValue);
+            $newEntry->recalculateTotalAmount();
+
+            $this->entityManager->persist($newEntry);
+            $this->entries[$entryIndex] = $newEntry;
+
+            return;
+        }
+
+        // Otheriwse, add amount to existing entry
+        $existingEntries[0]->$callSetter($updateValue);
+        $existingEntries[0]->recalculateTotalAmount();
+        $this->entries[$entryIndex] = $existingEntries[0];
+    }
+}

--- a/src/Command/FirstBatch/Version0/ImportOneZeroCommand.php
+++ b/src/Command/FirstBatch/Version0/ImportOneZeroCommand.php
@@ -4,87 +4,22 @@ declare(strict_types=1);
 
 namespace App\Command\FirstBatch\Version0;
 
-use App\Entity\BatchEntry;
-use App\Entity\BatchEntryPlace;
+use App\Command\BaseImportCommand;
+use App\Repository\BatchEntryPlaceRepository;
+use App\Repository\BatchEntryRepository;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Serializer\Encoder\CsvEncoder;
-use Symfony\Component\Serializer\Serializer;
 
-class ImportOneZeroCommand extends Command
+class ImportOneZeroCommand extends BaseImportCommand
 {
     protected static $defaultName = 'app:import-1.0';
+    const CSV_FILE = './public/file/first-batch/version-0/first-batch-0.csv';
+    const TARGET_VALUE = 'OneZeroAmount';
 
-    private EntityManagerInterface $entityManager;
-    private array $createdPlaces = [];
-
-    public function __construct(EntityManagerInterface $entityManager)
-    {
-        $this->entityManager = $entityManager;
-
-        parent::__construct();
-    }
-
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
-
-        $fileContent = file_get_contents('./public/file/first-batch/version-0/first-batch-0.csv');
-
-        if (!$fileContent) {
-            $io->success('Failed to open file');
-
-            return self::FAILURE;
-        }
-
-        $serializer = new Serializer([], [new CsvEncoder([
-            CsvEncoder::NO_HEADERS_KEY => true,
-            CsvEncoder::DELIMITER_KEY => ';',
-        ])]);
-
-        $csvContent = $serializer->decode($fileContent, 'csv');
-
-        $this->entityManager->getConnection()->getConfiguration()->setSQLLogger(null);
-
-        $i = 0;
-        foreach ($csvContent as $csvLine) {
-            $place = $this->findOrCreatePlace(trim($csvLine[1]));
-            $amount = str_replace(['.', ','], '', $csvLine[2]);
-
-            $entry = (new BatchEntry(trim($csvLine[0]), $place))
-                ->setOneZeroAmount((int) $amount)
-                ->recalculateTotalAmount();
-
-            $this->entityManager->persist($entry);
-
-            if ($i > 0 && $i % 5000 === 0) {
-                $this->entityManager->flush();
-                $io->writeln("Flushing @ ${i}");
-            }
-
-            ++$i;
-        }
-
-        $this->entityManager->flush();
-
-        $io->success('Finished importing');
-
-        return self::SUCCESS;
-    }
-
-    private function findOrCreatePlace(string $placeName): BatchEntryPlace
-    {
-        if (array_key_exists($placeName, $this->createdPlaces)) {
-            return $this->createdPlaces[$placeName];
-        }
-
-        $place = new BatchEntryPlace($placeName);
-        $this->entityManager->persist($place);
-        $this->createdPlaces[$placeName] = $place;
-
-        return $place;
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        BatchEntryRepository $batchEntryRepository,
+        BatchEntryPlaceRepository $batchEntryPlaceRepository
+    ) {
+        parent::__construct($entityManager, $batchEntryRepository, $batchEntryPlaceRepository);
     }
 }

--- a/src/Command/FirstBatch/Version1/ImportOneOneCommand.php
+++ b/src/Command/FirstBatch/Version1/ImportOneOneCommand.php
@@ -4,115 +4,23 @@ declare(strict_types=1);
 
 namespace App\Command\FirstBatch\Version1;
 
-use App\Entity\BatchEntry;
-use App\Entity\BatchEntryPlace;
+use App\Command\BaseImportCommand;
 use App\Repository\BatchEntryPlaceRepository;
 use App\Repository\BatchEntryRepository;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Serializer\Encoder\CsvEncoder;
-use Symfony\Component\Serializer\Serializer;
 
-class ImportOneOneCommand extends Command
+class ImportOneOneCommand extends BaseImportCommand
 {
     protected static $defaultName = 'app:import-1.1';
 
-    private EntityManagerInterface $entityManager;
-    private BatchEntryRepository $batchEntryRepository;
-    private BatchEntryPlaceRepository $batchEntryPlaceRepository;
+    const CSV_FILE = './public/file/first-batch/version-1/first-batch-1.csv';
+    const TARGET_VALUE = 'OneOneAmount';
 
     public function __construct(
         EntityManagerInterface $entityManager,
         BatchEntryRepository $batchEntryRepository,
         BatchEntryPlaceRepository $batchEntryPlaceRepository
     ) {
-        $this->entityManager = $entityManager;
-        $this->batchEntryRepository = $batchEntryRepository;
-        $this->batchEntryPlaceRepository = $batchEntryPlaceRepository;
-
-        parent::__construct();
-    }
-
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
-
-        $fileContent = file_get_contents('./public/file/first-batch/version-1/first-batch-1.csv');
-
-        if (!$fileContent) {
-            $io->success('Failed to open file');
-
-            return self::FAILURE;
-        }
-
-        $serializer = new Serializer([], [new CsvEncoder([
-            CsvEncoder::NO_HEADERS_KEY => true,
-            CsvEncoder::DELIMITER_KEY => ';',
-        ])]);
-
-        $csvContent = $serializer->decode($fileContent, 'csv');
-
-        $this->entityManager->getConnection()->getConfiguration()->setSQLLogger(null);
-
-        $i = 0;
-        foreach ($csvContent as $csvLine) {
-            $this->findOrCreateEntry($csvLine);
-
-            if ($i > 0 && $i % 5000 === 0) {
-                $this->entityManager->flush();
-                $io->writeln("Flushing @ ${i}");
-            }
-
-            ++$i;
-        }
-
-        $this->entityManager->flush();
-
-        $io->success('Finished importing');
-
-        return self::SUCCESS;
-    }
-
-    private function findOrCreatePlace(string $placeName): BatchEntryPlace
-    {
-        $existingPlace = $this->batchEntryPlaceRepository->findOneBy([
-            'name' => $placeName,
-        ]);
-
-        if ($existingPlace) {
-            return $existingPlace;
-        }
-
-        $place = new BatchEntryPlace($placeName);
-        $this->entityManager->persist($place);
-        $this->entityManager->flush();
-
-        return $place;
-    }
-
-    private function findOrCreateEntry(array $csvLine): void
-    {
-        $place = $this->findOrCreatePlace(trim($csvLine[1]));
-        $amount = str_replace(['.', ','], '', $csvLine[2]);
-
-        $existingEntries = $this->batchEntryRepository->findBy([
-            'companyName' => trim($csvLine[0]),
-            'place' => $place,
-        ]);
-
-        if (count($existingEntries) === 1) { // If able to match on name and place, add amount to existing entry, otherwise; create new one
-            $existingEntries[0]
-                ->setOneOneAmount((int) $amount)
-                ->recalculateTotalAmount();
-        } else {
-            $entry = (new BatchEntry(trim($csvLine[0]), $place))
-                ->setOneOneAmount((int) $amount)
-                ->recalculateTotalAmount();
-
-            $this->entityManager->persist($entry);
-        }
+        parent::__construct($entityManager, $batchEntryRepository, $batchEntryPlaceRepository);
     }
 }

--- a/src/Command/SecondBatch/Version0/ImportTwoZeroCommand.php
+++ b/src/Command/SecondBatch/Version0/ImportTwoZeroCommand.php
@@ -4,120 +4,23 @@ declare(strict_types=1);
 
 namespace App\Command\SecondBatch\Version0;
 
-use App\Entity\BatchEntry;
-use App\Entity\BatchEntryPlace;
+use App\Command\BaseImportCommand;
 use App\Repository\BatchEntryPlaceRepository;
 use App\Repository\BatchEntryRepository;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Serializer\Encoder\CsvEncoder;
-use Symfony\Component\Serializer\Serializer;
 
-class ImportTwoZeroCommand extends Command
+class ImportTwoZeroCommand extends BaseImportCommand
 {
     protected static $defaultName = 'app:import-2.0';
 
-    private EntityManagerInterface $entityManager;
-    private BatchEntryRepository $batchEntryRepository;
-    private BatchEntryPlaceRepository $batchEntryPlaceRepository;
+    const CSV_FILE = './public/file/second-batch/version-0/second-batch-0.csv';
+    const TARGET_VALUE = 'TwoZeroAmount';
 
     public function __construct(
         EntityManagerInterface $entityManager,
         BatchEntryRepository $batchEntryRepository,
         BatchEntryPlaceRepository $batchEntryPlaceRepository
     ) {
-        $this->entityManager = $entityManager;
-        $this->batchEntryRepository = $batchEntryRepository;
-        $this->batchEntryPlaceRepository = $batchEntryPlaceRepository;
-
-        parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this->setDescription('Imports the second batch of NOW data');
-    }
-
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
-
-        $fileContent = file_get_contents('./public/file/second-batch/version-0/second-batch-0.csv');
-
-        if (!$fileContent) {
-            $io->success('Failed to open file');
-
-            return self::FAILURE;
-        }
-
-        $serializer = new Serializer([], [new CsvEncoder([
-            CsvEncoder::NO_HEADERS_KEY => true,
-            CsvEncoder::DELIMITER_KEY => ';',
-        ])]);
-
-        $csvContent = $serializer->decode($fileContent, 'csv');
-
-        $this->entityManager->getConnection()->getConfiguration()->setSQLLogger(null);
-
-        $i = 0;
-        foreach ($csvContent as $csvLine) {
-            $this->findOrCreateEntry($csvLine);
-
-            if ($i > 0 && $i % 5000 === 0) {
-                $this->entityManager->flush();
-                $io->writeln("Flushing @ ${i}");
-            }
-
-            ++$i;
-        }
-
-        $this->entityManager->flush();
-
-        $io->success('Finished importing');
-
-        return self::SUCCESS;
-    }
-
-    private function findOrCreatePlace(string $placeName): BatchEntryPlace
-    {
-        $existingPlace = $this->batchEntryPlaceRepository->findOneBy([
-            'name' => $placeName,
-        ]);
-
-        if ($existingPlace) {
-            return $existingPlace;
-        }
-
-        $place = new BatchEntryPlace($placeName);
-        $this->entityManager->persist($place);
-        $this->entityManager->flush();
-
-        return $place;
-    }
-
-    private function findOrCreateEntry(array $csvLine): void
-    {
-        $place = $this->findOrCreatePlace(trim($csvLine[1]));
-        $amount = str_replace(['.', ','], '', $csvLine[2]);
-
-        $existingEntries = $this->batchEntryRepository->findBy([
-            'companyName' => trim($csvLine[0]),
-            'place' => $place,
-        ]);
-
-        if (count($existingEntries) === 1) { // If able to match on name and place, add amount to existing entry, otherwise; create new one
-            $existingEntries[0]
-                ->setTwoZeroAmount((int) $amount)
-                ->recalculateTotalAmount();
-        } else {
-            $entry = (new BatchEntry(trim($csvLine[0]), $place))
-                ->setTwoZeroAmount((int) $amount)
-                ->recalculateTotalAmount();
-
-            $this->entityManager->persist($entry);
-        }
+        parent::__construct($entityManager, $batchEntryRepository, $batchEntryPlaceRepository);
     }
 }

--- a/src/Command/ThirdBatch/Version0/ImportThreeZeroCommand.php
+++ b/src/Command/ThirdBatch/Version0/ImportThreeZeroCommand.php
@@ -4,122 +4,24 @@ declare(strict_types=1);
 
 namespace App\Command\ThirdBatch\Version0;
 
-use App\Entity\BatchEntry;
-use App\Entity\BatchEntryPlace;
+use App\Command\BaseImportCommand;
 use App\Repository\BatchEntryPlaceRepository;
 use App\Repository\BatchEntryRepository;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Serializer\Encoder\CsvEncoder;
-use Symfony\Component\Serializer\Serializer;
 
-class ImportThreeZeroCommand extends Command
+class ImportThreeZeroCommand extends BaseImportCommand
 {
-    const CSV_FILE = './public/file/third-batch/version-0/third-batch-0.csv';
-
     protected static $defaultName = 'app:import-3.0';
 
-    private EntityManagerInterface $entityManager;
-    private BatchEntryRepository $batchEntryRepository;
-    private BatchEntryPlaceRepository $batchEntryPlaceRepository;
+    const CSV_FILE = './public/file/third-batch/version-0/third-batch-0.csv';
+    const TARGET_VALUE = 'ThreeZeroAmount';
+    const DELIMITER = ',';
 
     public function __construct(
         EntityManagerInterface $entityManager,
         BatchEntryRepository $batchEntryRepository,
         BatchEntryPlaceRepository $batchEntryPlaceRepository
     ) {
-        $this->entityManager = $entityManager;
-        $this->batchEntryRepository = $batchEntryRepository;
-        $this->batchEntryPlaceRepository = $batchEntryPlaceRepository;
-
-        parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this->setDescription('Imports the second batch of NOW data');
-    }
-
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
-
-        $fileContents = file_get_contents(self::CSV_FILE);
-
-        if (!$fileContents) {
-            $io->error('Failed to open file');
-
-            return self::FAILURE;
-        }
-
-        $serializer = new Serializer([], [new CsvEncoder([
-            CsvEncoder::NO_HEADERS_KEY => true,
-            CsvEncoder::DELIMITER_KEY => ',',
-        ])]);
-
-        $csvContent = $serializer->decode($fileContents, 'csv');
-
-        $this->entityManager->getConnection()->getConfiguration()->setSQLLogger(null);
-
-        $i = 0;
-        foreach ($csvContent as $csvLine) {
-            $this->findOrCreateEntry($csvLine);
-
-            if ($i > 0 && $i % 5000 === 0) {
-                $this->entityManager->flush();
-                $io->writeln("Flushing @ ${i}");
-            }
-
-            ++$i;
-        }
-
-        $this->entityManager->flush();
-
-        $io->success('Finished importing');
-
-        return self::SUCCESS;
-    }
-
-    private function findOrCreatePlace(string $placeName): BatchEntryPlace
-    {
-        $existingPlace = $this->batchEntryPlaceRepository->findOneBy([
-            'name' => $placeName,
-        ]);
-
-        if ($existingPlace) {
-            return $existingPlace;
-        }
-
-        $place = new BatchEntryPlace($placeName);
-        $this->entityManager->persist($place);
-        $this->entityManager->flush();
-
-        return $place;
-    }
-
-    private function findOrCreateEntry(array $csvLine): void
-    {
-        $place = $this->findOrCreatePlace(trim($csvLine[1]));
-        $amount = str_replace(['.', ','], '', $csvLine[2]);
-
-        $existingEntries = $this->batchEntryRepository->findBy([
-            'companyName' => trim($csvLine[0]),
-            'place' => $place,
-        ]);
-
-        if (count($existingEntries) === 1) { // If able to match on name and place, add amount to existing entry, otherwise; create new one
-            $existingEntries[0]
-                ->setThreeZeroAmount((int) $amount)
-                ->recalculateTotalAmount();
-        } else {
-            $entry = (new BatchEntry(trim($csvLine[0]), $place))
-                ->setThreeZeroAmount((int) $amount)
-                ->recalculateTotalAmount();
-
-            $this->entityManager->persist($entry);
-        }
+        parent::__construct($entityManager, $batchEntryRepository, $batchEntryPlaceRepository);
     }
 }

--- a/src/Entity/BatchEntry.php
+++ b/src/Entity/BatchEntry.php
@@ -122,30 +122,30 @@ class BatchEntry
 
     // region Setters
 
-    public function setOneZeroAmount(int $oneZeroAmount): self
+    public function addOneZeroAmount(int $oneZeroAmount): self
     {
-        $this->oneZeroAmount = $oneZeroAmount;
+        $this->oneZeroAmount += $oneZeroAmount;
 
         return $this;
     }
 
-    public function setOneOneAmount(int $oneOneAmount): self
+    public function addOneOneAmount(int $oneOneAmount): self
     {
-        $this->oneOneAmount = $oneOneAmount;
+        $this->oneOneAmount += $oneOneAmount;
 
         return $this;
     }
 
-    public function setTwoZeroAmount(int $twoZeroAmount): self
+    public function addTwoZeroAmount(int $twoZeroAmount): self
     {
-        $this->twoZeroAmount = $twoZeroAmount;
+        $this->twoZeroAmount += $twoZeroAmount;
 
         return $this;
     }
 
-    public function setThreeZeroAmount(int $threeZeroAmount): self
+    public function addThreeZeroAmount(int $threeZeroAmount): self
     {
-        $this->threeZeroAmount = $threeZeroAmount;
+        $this->threeZeroAmount += $threeZeroAmount;
 
         return $this;
     }

--- a/templates/home.html.twig
+++ b/templates/home.html.twig
@@ -26,7 +26,7 @@
                     </div>
                     <div class="card-body">
                         <h3 class="card-title mb-0">
-                            € 14.401.919.308
+                            € 14.433.319.056
                         </h3>
                     </div>
                 </div>
@@ -38,7 +38,7 @@
                     </div>
                     <div class="card-body">
                         <h3 class="card-title mb-0">
-                            168.542
+                            155.601
                         </h3>
                     </div>
                 </div>
@@ -50,7 +50,7 @@
                     </div>
                     <div class="card-body">
                         <h3 class="card-title mb-0">
-                            € 85.450
+                            € 92.759
                         </h3>
                     </div>
                 </div>


### PR DESCRIPTION
Heb de importers opgeschoond en de bug in #5 gefixt door in-memory de entries te cachen & bij te werken tot aan de flush.

Toevallig is het gegeven voorbeeld in dat issue alsnog niet één entry omdat in de laatste CSV een formatting issue zit:
```
ZAANKRACHT UITZENDBUREAU            SCHIPHOL B.V.
ZAANKRACHT UITZENDBUREAU SCHIPHOL B.V.
```

Maar omdat nu alle importers een stuk generieker zijn, is het wel eenvoudiger geworden om één plek de formatting op te schonen om dit soort entries alsnog samen te voegen (dubbele spaties trimmen etc.).